### PR TITLE
1.19.2 - Shift clicking into an energy condenser MK1 crashes the game

### DIFF
--- a/src/main/java/com/skirlez/fabricatedexchange/screen/EnergyCondenserScreenHandler.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/screen/EnergyCondenserScreenHandler.java
@@ -96,8 +96,12 @@ public class EnergyCondenserScreenHandler extends LeveledScreenHandler implement
 
             if (itemStack2.isEmpty())
                 slot2.setStack(ItemStack.EMPTY);
-            else
-                slot2.markDirty();
+            else {
+                itemStack.setCount(1);
+                FakeSlot fakeSlot = (FakeSlot) slots.get(0);
+                fakeSlot.setStack(itemStack);
+                return ItemStack.EMPTY;
+            }
         }
 
         return itemStack;


### PR DESCRIPTION
Made the fake slot take the shift clicked item and the slot clicked to retain the itemstack.