### PR TITLE
1.19.4 Energy Condenser Crash and YAML patch

### DIFF
--- a/src/main/java/com/skirlez/fabricatedexchange/screen/EnergyCondenserScreenHandler.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/screen/EnergyCondenserScreenHandler.java
@@ -96,8 +96,12 @@ public class EnergyCondenserScreenHandler extends LeveledScreenHandler implement
 
 			if (itemStack2.isEmpty())
 				slot2.setStack(ItemStack.EMPTY);
-			else
-				slot2.markDirty();
+			else {
+				itemStack.setCount(1);
+				FakeSlot fakeSlot = (FakeSlot) slots.get(0);
+				fakeSlot.setStack(itemStack);
+				return ItemStack.EMPTY;
+			}
 		}
 
 		return itemStack;

--- a/src/main/java/com/skirlez/fabricatedexchange/util/config/lib/ConfigFile.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/util/config/lib/ConfigFile.java
@@ -38,7 +38,11 @@ public abstract class ConfigFile<T> extends AbstractFile<T> {
 
 	@Override
 	protected T readValue(Reader reader) throws Exception {
-		return YAML.loadAs(reader, (Class<?>)type);
+		if (type instanceof Class<?>) {
+			return YAML.loadAs(reader, (Class<T>) type);
+		} else {
+			throw new IllegalArgumentException("Type must be a Class object");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Made the fakeSlot take the shift clicked item and the slot clicked to retain the itemstack.

Additionally, added an exception catch for the YMAL reader.