### PR TITLE
add philosopher's stone world transmutation emi recipe support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,10 @@ dependencies {
     modImplementation("com.terraformersmc:modmenu:${project.modmenu}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
-	
+
+	modCompileOnly "dev.emi:emi-fabric:${emi_version}:api"
+	modLocalRuntime "dev.emi:emi-fabric:${emi_version}"
+
 	implementation 'org.yaml:snakeyaml:2.2'
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.16.1'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,6 @@ maven_group=com.skirlez
 archives_base_name=fabricated-exchange
 
 modmenu=6.3.1
+emi_version=1.1.4+1.19.4
 
 modid=fabricated-exchange

--- a/src/main/java/com/skirlez/fabricatedexchange/emi/FabricatedExchangeEmiPlugin.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/emi/FabricatedExchangeEmiPlugin.java
@@ -1,0 +1,27 @@
+package com.skirlez.fabricatedexchange.emi;
+
+import com.skirlez.fabricatedexchange.item.ModItems;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.block.Block;
+import net.minecraft.util.Identifier;
+import com.skirlez.fabricatedexchange.BlockTransmutation;
+
+import java.util.Map;
+
+public class FabricatedExchangeEmiPlugin implements EmiPlugin {
+    public static final Identifier PHILOSOPHERS_STONE_ICON = new Identifier("fabricated-exchange", "textures/philosophers_stone.png");
+    public static final EmiStack PHILOSOPHERS_STONE_ITEM = EmiStack.of(ModItems.PHILOSOPHERS_STONE);
+    public static final EmiRecipeCategory PHILOSOPHERS_STONE_CATEGORY = new EmiRecipeCategory(new Identifier("fabricated-exchange", "philosophers_stone"), PHILOSOPHERS_STONE_ITEM, new EmiTexture(PHILOSOPHERS_STONE_ICON, 0, 0, 16, 16));
+    @Override
+    public void register(EmiRegistry registry) {
+        registry.addCategory(PHILOSOPHERS_STONE_CATEGORY);
+        registry.addWorkstation(PHILOSOPHERS_STONE_CATEGORY, PHILOSOPHERS_STONE_ITEM);
+        for (Map.Entry<Block, Block> entry : BlockTransmutation.blockTransmutationMap.entrySet()) {
+            registry.addRecipe(new TransmutationEmiRecipe(entry.getKey(), entry.getValue()));
+        }
+    }
+}

--- a/src/main/java/com/skirlez/fabricatedexchange/emi/TransmutationEmiRecipe.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/emi/TransmutationEmiRecipe.java
@@ -1,0 +1,64 @@
+package com.skirlez.fabricatedexchange.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import net.minecraft.block.Block;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.util.Identifier;
+
+import java.util.List;
+
+public class TransmutationEmiRecipe implements EmiRecipe {
+    private final Identifier id;
+    private final EmiIngredient input;
+    private final EmiStack output;
+
+    public TransmutationEmiRecipe(Block input, Block output) {
+        this.id = Identifier.of("fabricated-exchange", String.format("%s>%s", input, output));
+        this.input = EmiIngredient.of(Ingredient.ofItems(input));
+        this.output = EmiStack.of(output);
+    }
+
+    @Override
+    public EmiRecipeCategory getCategory() {
+        return FabricatedExchangeEmiPlugin.PHILOSOPHERS_STONE_CATEGORY;
+    }
+
+    @Override
+    public Identifier getId() {
+        return id;
+    }
+
+    @Override
+    public List<EmiIngredient> getInputs() {
+        return List.of(input);
+    }
+
+    @Override
+    public List<EmiStack> getOutputs() {
+        return List.of(output);
+    }
+
+    @Override
+    public int getDisplayWidth() {
+        return 125;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 18;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        widgets.addSlot(input, 0, 0);
+        widgets.addTexture(EmiTexture.PLUS, 27, 3);
+        widgets.addSlot(FabricatedExchangeEmiPlugin.PHILOSOPHERS_STONE_ITEM, 49, 0);
+        widgets.addTexture(EmiTexture.EMPTY_ARROW, 75, 1);
+        widgets.addSlot(output, 107, 0).recipeContext(this);
+    }
+}

--- a/src/main/resources/assets/fabricated-exchange/lang/en_us.json
+++ b/src/main/resources/assets/fabricated-exchange/lang/en_us.json
@@ -166,5 +166,7 @@
     "config.fabricated-exchange.energyCollector.alwaysHaveEnergy_1": "When enabled, the Energy Collectors will always have light energy, even in darkness.",
     "config.fabricated-exchange.energyCollector.alwaysHaveEnergy_2": "(default: false)",
     
-    "tag.item.c.transmutation_fuel": "Transmutation Fuel"
+    "tag.item.c.transmutation_fuel": "Transmutation Fuel",
+
+    "emi.category.fabricated-exchange.philosophers_stone": "World Transmutation"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,7 +26,10 @@
 		],
 		"modmenu": [ 
 			"com.skirlez.fabricatedexchange.util.config.ModMenuSettings"
-	 	]
+		],
+		"emi": [
+			"com.skirlez.fabricatedexchange.emi.FabricatedExchangeEmiPlugin"
+		]
 	},
 	"mixins": [
 		"fabricated-exchange.mixins.json",


### PR DESCRIPTION
add basic support for [EMI](https://modrinth.com/mod/emi) by showing what blocks the philosopher's stone can transmute

adds an optional dependency on any version of EMI, tested with 1.1.4 (latest) and 0.7.1 (earliest 1.19.4 version)

![emi support](https://github.com/Skirlez/fabricated-exchange/assets/144726229/b6c1627f-9a2f-4678-8bda-bbbf1a9613ce)
