### PR TITLE
Altered Gem of Eternal Density

### DIFF
--- a/src/main/java/com/skirlez/fabricatedexchange/item/tools/base/FEHammer.java
+++ b/src/main/java/com/skirlez/fabricatedexchange/item/tools/base/FEHammer.java
@@ -192,8 +192,8 @@ public abstract class FEHammer extends PickaxeItem implements ChargeableItem, Ou
 						}
 					}
 
-					// Capture drops from the center block
-					if (!blockState.isAir()) {
+					// Only handle the center block if it's not already in the list of positions to mine
+					if (!positionsToMine.contains(pos) && !blockState.isAir()) {
 						LootContext.Builder builder = new LootContext.Builder((ServerWorld) world)
 								.random(world.random)
 								.parameter(LootContextParameters.ORIGIN, hitResult.getPos())


### PR DESCRIPTION
Altered the gem logic to be more like a mining utility item, focused on raw ores only, converting only specific blocks/items.

Also removed red matter tier as it doesnt make sense to me that a gem built of dark matter would allow creation of red matter, plus that is how it was in the original mod

also ignore the hammer changes, once the other PR is merged those commits will vanish, its because I needed a build for KMF so had both merge into my main branch! 